### PR TITLE
Strip ANSI colors from txt log rather than convert to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This document tries to help FPF/SD engineers install the scripts on a Qubes 4.1+
 
 5. Put `sdci-repo-webhook.service` in `/etc/systemd/system/`. Configure a webhook 'secret' in this systemd file. Also adjust the `FLASK_RUN_HOST` to the IP of your sd-ssh machine's Tailscale IP.
 
-6. Install some dependencies: `sudo dnf install python3-pip python3-flask python3-paramiko python3-scp python3-ansi2html; sudo pip3 install github-webhook`
+6. Install some dependencies: `sudo dnf install python3-pip python3-flask python3-paramiko python3-scp; sudo pip3 install github-webhook`
 
 7. Enable and start the flask service via systemd: `systemctl daemon-reload; systemctl enable sdci-repo-webhook; systemctl start sdci-repo-webhook`
 

--- a/runner.py
+++ b/runner.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import qubesadmin
+import re
 import shlex
 import shutil
 import subprocess
@@ -85,9 +86,11 @@ class QubesCI:
             return timestamp
 
         def log_subprocess_output(pipe):
+            ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
             for line in pipe:
                 timestamp = format_current_timestamp()
-                self.logging.info(f"[{timestamp}] {line.decode('utf-8')}")
+                line_decoded = ansi_escape.sub('', line.decode('utf-8'))
+                self.logging.info(f"[{timestamp}] {line_decoded}")
 
         command_line_args = shlex.split(cmd)
         timestamp = format_current_timestamp()

--- a/upload-report
+++ b/upload-report
@@ -2,7 +2,6 @@
 
 import argparse
 import requests
-from ansi2html import Ansi2HTMLConverter
 from paramiko import SSHClient
 from scp import SCPClient
 
@@ -38,21 +37,11 @@ def upload_report(report):
     """
     Uploads the report to the CI runner proxy
     """
-    # First, make a .html copy of our .txt report with the
-    # ANSI colors converted to span styles
-    conv = Ansi2HTMLConverter()
-    report_file_html = report.replace(".txt", ".html")
-    report_path = "/home/user/QubesIncoming/dom0"
-    with open(f"{report_path}/{report}", "r") as report_txt:
-        with open(f"{report_path}/{report_file_html}", "w") as report_html:
-            report_html.write(conv.convert("".join(report_txt.readlines())))
-
-    # Upload the HTML report to the proxy
     ssh_ob = SSHClient()
     ssh_ob.load_system_host_keys()
     ssh_ob.connect(hostname="ws-ci-runner.securedrop.org", username="wscirunner")
     scp = SCPClient(ssh_ob.get_transport())
-    scp.put(f"{report_path}/{report_file_html}", remote_path="/var/www/html/reports")
+    scp.put(f"/home/user/QubesIncoming/dom0/{report}", remote_path="/var/www/html/reports")
     scp.close()
 
 
@@ -75,8 +64,6 @@ def report_status(status, sha, report):
             "Authorization": f"Bearer {github_token}",
             "Content-Type": "application/json",
     }
-    # We are pointing to our HTML copy of the report
-    report = report.replace(".txt", ".html")
     data = {
         "state": status,
         "target_url": f"https://ws-ci-runner.securedrop.org/{report}",


### PR DESCRIPTION
Closes #4 

We are back to a txt file with the ansi symbols removed: https://ws-ci-runner.securedrop.org/2023-04-04-104440172906.log.txt

We can add a CSP to the proxy vhost later once we finalize the setup..