### PR TITLE
Use an explicit filename for the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This document tries to help FPF/SD engineers install the scripts on a Qubes 4.1+
 
 9. Configure the webhook in your repository for the 'push' event, with the same secret you put in the systemd file in step 5. The URL would be https://ws-ci-runner.securedrop.org/hook/postreceive per https://github.com/freedomofpress/infrastructure/pull/4111 . You will also need to have an Nginx proxy somewhere answering for the 'outer' HTTPS request, and proxying through to your sd-ssh machine's port 5000 Flask app (via Tailscale)
 
-10. Generate an SSH key on sd-ssh, and ensure this key is in the `/home/wscirunner/.ssh/authorized_keys` on the ws-ci-runner droplet proxy (so that `upload-file` can scp up the log results). You may need to ssh to the ws-ci-runner the first time to accept the host key signature
+10. Generate an SSH key on sd-ssh with `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_sdci_upload`, and ensure this key is in the `/home/wscirunner/.ssh/authorized_keys` on the ws-ci-runner droplet proxy (so that `upload-file` can scp up the log results). Run `ssh -i ~/.ssh/id_ed25519_sdci_upload wscirunner@ws-ci-runner.securedrop.org` once to accept the host key signature.
 
 
 ## Test it

--- a/upload-report
+++ b/upload-report
@@ -50,7 +50,7 @@ def upload_report(report):
     # Upload the HTML report to the proxy
     ssh_ob = SSHClient()
     ssh_ob.load_system_host_keys()
-    ssh_ob.connect(hostname="ws-ci-runner.securedrop.org", username="wscirunner")
+    ssh_ob.connect(hostname="ws-ci-runner.securedrop.org", username="wscirunner", key_filename="/home/user/.ssh/id_ed25519_sdci_upload")
     scp = SCPClient(ssh_ob.get_transport())
     scp.put(f"{report_path}/{report_file_html}", remote_path="/var/www/html/reports")
     scp.close()


### PR DESCRIPTION
Previously we were depending on the default generated ssh key filename being picked up automatically by Paramiko. However, if you want to have multiple keys on sd-ssh, in order to pull from GitHub without mixing authentication there and to the droplet, this can be frustrating.

I personally like to always generate single-purpose keypairs and be explicit about filenames, so I have done that here and updated the instructions (including the manual accepting the fingerprint into `known_hosts` step), but if we don't like that, we could try something else.

I investigated if Paramiko can parse a `.ssh/config` (it can) and then use that automatically to connect (it can't; it looks like you have to pull values out yourself), so abandoned that approach.