### PR TITLE
Push commit statuses to upstream repo. Add the call to upload-report when a job is pending (queued)

### DIFF
--- a/upload-report
+++ b/upload-report
@@ -84,7 +84,7 @@ def report_status(status, sha, report):
         status = "pending"
     data["state"] = status
 
-    r = requests.post(f"https://api.github.com/repos/mig5/securedrop-workstation/statuses/{sha}", json=data, headers=headers)
+    r = requests.post(f"https://api.github.com/repos/freedomofpress/securedrop-workstation/statuses/{sha}", json=data, headers=headers)
 
 
 if __name__ == "__main__":

--- a/webhook.py
+++ b/webhook.py
@@ -30,6 +30,16 @@ def on_push(data):
     # Copy the config files we need
     shutil.copyfile("config.json", f"{workspace}/config.json")
     shutil.copyfile("sd-journalist.sec", f"{workspace}/sd-journalist.sec")
+
+    # Post pending status back to Github
+    subprocess.check_call([
+        "/home/user/bin/upload-report",
+        "--status",
+        "pending",
+        "--sha",
+        commit
+    ])
+
     # RPC call to trigger running the build on dom0
     # Note: I don't call p.communicate() (or use check_call()/check_output() instead of Pppen)
     # because it otherwise waits for the dom0 runner.py to finish, which takes a long time, and


### PR DESCRIPTION
The webhook.py 'pending' thing is just something I forgot to commit last time. It fires before sending the RPC call to the dom0, so that Github knows the build is at least 'pending'.

That way, if there's already a build running, that commit stays in 'pending' state for that time.

Once the job starts, runner.py also executes upload-report with the status of 'running'. So most of the time, if there's no queued up builds, the commit status very quickly changes from 'pending' to 'running'.

The other change is just to reflect that we are now using the webhook on the the upstream repo so am sending the commit statuses there instead of to my fork..