### PR TITLE
Run docker system prune --force during teardown

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -246,9 +246,13 @@ class QubesCI:
                 f"qvm-run {self.securedrop_dev_vm} rm -rf {self.securedrop_dev_dir}",
                 teardown=True,
             )
-            # Remove the Docker image
+            # Remove the Docker image and prune
             self.run_cmd(
                 f"qvm-run {self.securedrop_dev_vm} docker rmi securedrop-workstation-dom0-config",
+                teardown=True,
+            )
+            self.run_cmd(
+                f"qvm-run {self.securedrop_dev_vm} docker system prune --force",
                 teardown=True,
             )
 


### PR DESCRIPTION
Relates to https://github.com/freedomofpress/securedrop-workstation-ci/issues/20 .

The prune only adds 2 minutes of extra build time on my setup.