### PR TITLE
If a run_cmd fails, upload log and report failure, and abort immediately

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -81,9 +81,9 @@ class QubesCI:
         # If so, attempt an optimistic teardown sequence.
         if os.path.exists(self.dirty_file):
             self.teardown(early=True)
-        # Else, create the dirty file while running.. a successful teardown will remove it
-        else:
-            open(self.dirty_file, "w").close()
+
+        # Create the dirty file while running.. a successful teardown will remove it
+        open(self.dirty_file, "w").close()
 
     def run_cmd(self, cmd, teardown=False, ignore_errors=False):
         """
@@ -133,6 +133,9 @@ class QubesCI:
                     self.status = "success"
             else:
                 self.status = "failure"
+                # We failed on a step, so stop the build, and upload the results
+                self.uploadLog()
+                sys.exit(1)
         else:
             self.logging.info(f"[{timestamp}] Step finished")
 


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/securedrop-workstation/issues/895

This PR also fixes an unrelated, subtle bug: the 'early teardown' occurs when it detects a dirty file is still present (from the last build). However, the end of a teardown process *removes* the dirty file if all went well.

So after an early teardown, the dirty file no longer existed for the rest of the build process, whereas it normally would. 

The risk would be that if the rest of the build process following an early teardown *also* happened to fail for any reason, then the *next* build would not find any dirty file, and so would not attempt an early teardown.

Fixed by removing an `else` condition, ensuring we always create the dirty file even after an early teardown has run.