### PR TITLE
Don't run CI when a branch was deleted

### DIFF
--- a/webhook.py
+++ b/webhook.py
@@ -20,6 +20,14 @@ def on_push(data):
     repo = data["repository"]["name"]
     ssh_url = data["repository"]["clone_url"]
     commit = data["after"]
+
+    # When a branch is deleted, a webhook payload contains
+    # a commit that is all zeros, and an attribute of 'deleted' => true
+    # In that case, exit early.
+    if commit == "0000000000000000000000000000000000000000" and data.get("deleted", False):
+        logging.info(f"Event is branch deletion, not running CI for {ref}")
+        return
+
     logging.info(f"running on {ref}")
     # checkout that relevant commit
     workspace = f"{repo}_{commit}"


### PR DESCRIPTION
When a branch gets deleted, the webhook fires, but the 'after' key in the payload is a series of zeroes. There is also a key `deleted` which has a value of `true`.


Example:

```
{
  "ref": "refs/heads/mig5-ci-test",
  "before": "ef1b1e0c48b3d3486c5e719b96cd8ef6b3cf798a",
  "after": "0000000000000000000000000000000000000000",
[...]
  "created": false,
  "deleted": true,
  "forced": false,
  "base_ref": null,
  "compare": "https://github.com/freedomofpress/securedrop-workstation/compare/ef1b1e0c48b3...000000000000",
  "commits": [

  ],
  "head_commit": null
}
```

Our webhook dutifully runs but doesn't like the commit hash of `0000000000000000000000000000000000000000` and ends up throwing a fatal error back to Github (at the webhook delivery layer - it doesn't get as far as actually running CI though it clones the repo and tries to checkout this hash).

Adding a simple early return in that scenario to avoid the noisy red error in the webhook interface in Github, and to reduce cruft on the sd-ssh VM.