### PR TITLE
Skip CI for branches that have skip-ci in the name

### DIFF
--- a/webhook.py
+++ b/webhook.py
@@ -28,6 +28,11 @@ def on_push(data):
         logging.info(f"Event is branch deletion, not running CI for {ref}")
         return
 
+    # Ignore branches that have skip-ci in the name
+    if "skip-ci" in ref:
+        logging.info(f"Skipping CI for {ref}")
+        return
+
     logging.info(f"running on {ref}")
     # checkout that relevant commit
     workspace = f"{repo}_{commit}"


### PR DESCRIPTION
Coming out of a discussion in https://github.com/freedomofpress/securedrop-workstation/pull/897#issuecomment-1574046035

Out of convention, we will skip CI if the branch/ref name contains 'skip-ci' in it.

This is already in place on my CI instance.

(@maeve-fpf, unrelated to this PR but while you were away I also pushed a few other changes, you may want to update yours to pick up these changes as well if you haven't already:

https://github.com/freedomofpress/securedrop-workstation-ci/pull/21
https://github.com/freedomofpress/securedrop-workstation-ci/pull/23
https://github.com/freedomofpress/securedrop-workstation-ci/pull/24

See also the new install docs at https://github.com/freedomofpress/securedrop-workstation-ci/pull/22)