### PR TITLE
Runner fixes for teardown

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -131,6 +131,9 @@ class QubesCI:
                 # depending on where last build failed
                 if ignore_errors:
                     self.status = "success"
+                else:
+                    self.uploadLog()
+                    sys.exit(1)
             else:
                 self.status = "failure"
                 # We failed on a step, so stop the build, and upload the results


### PR DESCRIPTION
Fixes #31 
Fixes #32 

I'm adding a simple if/else condition for whether the clean-salt and destroy-vm scripts exist in the `scripts/` dir or `files/`. The latter is true on main branch, but the former is true on older branches of 0.8.x. It's a bit of a null change anyway because 0.8.x doesn't build on our CI due to the Fedora version. But, I didn't like the way the script was bombing out due to the path not existing.

The second commit deals with the fact that the former issue was causing the teardown to abort immediately, and it never got the chance to upload its log file or send a commit status saying there was an error. This ensures it does. You can see evidence of that in [this log](https://ws-ci-runner.securedrop.org/2023-06-28-062417390926.log.txt) as an example. Previously, such an exception during teardown would've just caused the script to exit, but there'd be no log uploaded, nor a commit status, and the commit would appear to still be in 'Pending: the build is running' state.