### PR TITLE
Redirect stdin from /dev/null

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -115,6 +115,7 @@ class QubesCI:
 
         p = subprocess.Popen(
             command_line_args,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )


### PR DESCRIPTION
An `input()` call was recently added to the install; add an explicit equivalent of `< /dev/null` to our `run_cmd` so that this can be handled. May need some SDW-side code changes.