### PR TITLE
Invoke the venv in nightlies.py when calling run.py

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -56,6 +56,7 @@ def nightly(branch):
                 qubes_version = yaml_data["qubes"]
                 if re.match(r'^\d+\.\d+$', qubes_version):
                     subprocess.Popen([
+                        "/home/wscirunner/venv/bin/python",
                         "/home/wscirunner/securedrop-workstation-ci/run.py",
                         "--version",
                         qubes_version,


### PR DESCRIPTION
Relates to: https://github.com/freedomofpress/infrastructure/pull/4747