### PR TITLE
Set `CI=true` in environment when running tests

### DIFF
--- a/dom0/runner.py
+++ b/dom0/runner.py
@@ -101,7 +101,7 @@ class QubesCI:
                 raise SystemExit(msg)
         self.logging.info("All SecureDrop Workstation VMs shut down")
 
-    def run_cmd(self, cmd):
+    def run_cmd(self, cmd, env=None):
         """
         Run any command as a subprocess, and ensure both its
         stdout and stderr get logged to the logging handler.
@@ -129,8 +129,13 @@ class QubesCI:
         timestamp = format_current_timestamp()
         self.logging.info(f"[{timestamp}] Running: {cmd}")
 
+        merged_env = os.environ.copy()
+        if env is not None:
+            merged_env.update(env)
+
         p = subprocess.Popen(
             command_line_args,
+            env=merged_env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -184,7 +189,7 @@ class QubesCI:
         self.run_cmd("make clone")
         self.run_cmd("make dev")
         self.shutdown_sd_vms()
-        self.run_cmd("make test")
+        self.run_cmd("make test", env={"CI": "true"})
 
     def systemInfo(self):
         """


### PR DESCRIPTION
In <https://github.com/freedomofpress/securedrop-workstation/pull/984>, we've identified a use-case in which we want to vary behavior based on whether we're running in CI or not. `CI=true` is a generic variable based on the npm `ci-detect` and Rust `is_ci` libraries.[1][2]

[1] https://github.com/npm/ci-detect?tab=readme-ov-file#cis-detected
[2] https://github.com/zkat/is_ci/blob/5e7959455a90cf9a00cafbbd533ea25d747a07d3/src/lib.rs#L27