### PR TITLE
Context file name to temporarily have a pseudo-unique suffix, to avoid concurrent clobbering

### DIFF
--- a/sd-dev/bin/begin.py
+++ b/sd-dev/bin/begin.py
@@ -23,7 +23,7 @@ def run():
     subprocess.run(["sudo", "chown", "user:user", working_dir])
 
     # Read context in from file
-    context_filepath = "/home/user/QubesIncoming/dom0/context.json"
+    context_filepath = "/home/user/context.json"
     if os.path.exists(context_filepath):
         with open(context_filepath, "r") as context_file:
             try:

--- a/sd-dev/bin/status.py
+++ b/sd-dev/bin/status.py
@@ -41,7 +41,7 @@ class Status:
         self.logger.addHandler(handler)
 
         # Read context in from file
-        context_filepath = "/home/user/QubesIncoming/dom0/context.json"
+        context_filepath = "/home/user/context.json"
         if os.path.exists(context_filepath):
             with open(context_filepath, "r") as context_file:
                 # Load in the JSON


### PR DESCRIPTION
Follow up to https://github.com/freedomofpress/securedrop-workstation-ci/pull/52

@legoktm, I realised I was writing the context to a file on the bastion called `context.json` - this file is then copied into the sd-dev by way of dom0 (by way of VMtoolsd file transfer from the bastion).

I grew concerned that if there are two concurrent CI runs taking place, a race condition (e.g regarding boot-up time) could lead to one 'clobbering' the contents of the `context.json` file before the other gets a chance to transfer it to the dom0. This could lead to incorrect information in the Slack notification for the running commit.

As a simple workaround I'm naming the context file to briefly have the commit hash in the name. By the time it ends up in sd-dev, it gets renamed to `context.json` there, which is safe. The name only needs to be 'unique' while the file rests on the bastion. 

I'm also now deleting the file off the bastion once we no longer need it, otherwise it ends up staying in `/home/wscirunner/securedrop-workstation-ci/` as an uncommitted file in that cloned git repo (it's not .gitignored, guess we could also gitignore `*.json` if we really wanted).

I didn't bother spending the time making a more random name for the file, I'm operating on the assumption that there won't be a concurrent CI run with the  same commit hash (especially after https://github.com/freedomofpress/securedrop-workstation-ci/issues/60 / https://github.com/freedomofpress/infrastructure/pull/4822 goes in!)

Please review and merge if you agree - if you want to make the file name even more random with a uuid or random() or something, feel free to have at it.