### PR TITLE
Add pytest and pytest-cov dependencies to dom0

### DIFF
--- a/dom0/runner.py
+++ b/dom0/runner.py
@@ -160,6 +160,9 @@ class QubesCI:
         # synchronize dom0 clock
         self.run_cmd("sudo qvm-sync-clock")
 
+        # Install testing dependencies
+        self.run_cmd("sudo qubes-dom0-update -y python3-pytest python3-pytest-cov")
+
     def build(self):
         """
         Build the package


### PR DESCRIPTION
Add necessary dom0 dependencies to run pytest in dom0, according to [1].

Fixes #81

[1]: https://github.com/freedomofpress/securedrop-workstation/pull/1329/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R145-R152